### PR TITLE
fix for issue 13: bugs of _str_split() function

### DIFF
--- a/project4/tac.c
+++ b/project4/tac.c
@@ -50,7 +50,7 @@ char** _str_split(char* str, const char delim, int *n) {
     count += last_comma < (str + strlen(str) - 1);
     *n = count;
 
-    result = malloc(sizeof(char*) * count);
+    result = malloc(sizeof(char*) * (count + 1));
     if (result) {
         size_t idx  = 0;
         char* token = strtok(str, delims);

--- a/project4/tac.c
+++ b/project4/tac.c
@@ -32,6 +32,12 @@ char** _str_split(char* str, const char delim, int *n) {
     // from: https://stackoverflow.com/questions/9210528/
     char** result    = 0;
     size_t count     = 0;
+    if ((strlen(str) == 0) || ( str == NULL ) || ( delim == '\0' ))
+    {
+        /* Either of those will cause problems */
+        *n = -1;
+        return result; // return NULL
+    }
     char* tmp        = str;
     char* last_comma = 0;
     char delims[2];
@@ -63,6 +69,11 @@ char** _str_split(char* str, const char delim, int *n) {
         assert(idx == count);
         *(result + idx) = 0;
     }
+    // for (int i = 0; i < count; i++)
+    // {
+    //     printf("%d-%s;", i, result[i]);
+    // }
+    // putchar('\n');
     return result;
 }
 
@@ -209,6 +220,10 @@ tac *tac_from_buffer(char *buf){
         }
         else{
             lnbuf[i] = '\0';
+            // empty line
+            if (strlen(lnbuf) == 0){
+                continue;
+            }
             inst = _tac_from_line(lnbuf);
             tac_append(self, inst);
             i = 0;

--- a/project4/tac.c
+++ b/project4/tac.c
@@ -30,7 +30,7 @@ char *_str_trim(char *str) {
 
 char** _str_split(char* str, const char delim, int *n) {
     // from: https://stackoverflow.com/questions/9210528/
-    if (*str == '\0' || str == NULL || delim == '\0' )
+    if (*str == '\0' || str == NULL || delim == '\0')
     {
         // Either of those will cause problems
         *n = -1;

--- a/project4/tac.c
+++ b/project4/tac.c
@@ -30,14 +30,15 @@ char *_str_trim(char *str) {
 
 char** _str_split(char* str, const char delim, int *n) {
     // from: https://stackoverflow.com/questions/9210528/
-    char** result    = 0;
-    size_t count     = 0;
-    if ((strlen(str) == 0) || ( str == NULL ) || ( delim == '\0' ))
+    if (*str == '\0' || str == NULL || delim == '\0' )
     {
-        /* Either of those will cause problems */
+        // Either of those will cause problems
         *n = -1;
         return NULL;
     }
+
+    char** result    = 0;
+    size_t count     = 0;
     char* tmp        = str;
     char* last_comma = 0;
     char delims[2];

--- a/project4/tac.c
+++ b/project4/tac.c
@@ -36,7 +36,7 @@ char** _str_split(char* str, const char delim, int *n) {
     {
         /* Either of those will cause problems */
         *n = -1;
-        return result; // return NULL
+        return NULL;
     }
     char* tmp        = str;
     char* last_comma = 0;
@@ -69,11 +69,6 @@ char** _str_split(char* str, const char delim, int *n) {
         assert(idx == count);
         *(result + idx) = 0;
     }
-    // for (int i = 0; i < count; i++)
-    // {
-    //     printf("%d-%s;", i, result[i]);
-    // }
-    // putchar('\n');
     return result;
 }
 
@@ -104,6 +99,10 @@ tac *_tac_from_line(char *ln){
 
     ln = _str_trim(ln);
     tokens = _str_split(ln, ' ', &count);
+
+    if (tokens == NULL){
+        return tac_init_none();
+    }
 
     if(count == 2){
         code = tac_init_none();
@@ -220,10 +219,6 @@ tac *tac_from_buffer(char *buf){
         }
         else{
             lnbuf[i] = '\0';
-            // empty line
-            if (strlen(lnbuf) == 0){
-                continue;
-            }
             inst = _tac_from_line(lnbuf);
             tac_append(self, inst);
             i = 0;


### PR DESCRIPTION
Fixes #13 

I've already made a detailed description about this bug at https://github.com/sqlab-sustech/CS323-2021F/issues/13#issuecomment-1002853319.

---

However, after this modification, I can reproduce @bzy-debug's issue.

![image](https://user-images.githubusercontent.com/57553691/147800685-78dd3662-9441-4924-bb77-a2f8647e9fb7.png)

The reason is that `_str_split()` does not check empty input.

Therefore, I will try to fix this.